### PR TITLE
Update readme to document usage with karma

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,33 +50,40 @@ Browser versions: `bdd_lazy_var.js`, `bdd_lazy_var_global.js`, `bdd_lazy_var_get
 Node versions: `index.js`, `global.js`, `getter.js`.
 
 ## How to use
-Command line: `mocha -u bdd-lazy-var` or in JavaScript:
+
+#### Command line
+```sh
+mocha -u bdd-lazy-var
+```
+
+#### In JavaScript
 ```js
 var mocha = new Mocha({
   ui: 'bdd-lazy-var' // bdd-lazy-var/global or bdd-lazy-var/getter
 });
 ```
-If you run tests in browser, you need to require/load `bdd_lazy_var*.js` (i.e., `bdd_lazy_var.js`, `bdd_lazy_var_getter.js` or `bdd_lazy_var_global.js`) and then `ui` option for mocha should be `bdd-lazy-var/global` (or `bdd-lazy-var/getter` or `bdd-lazy-var`, depends on which you prefer).
+
+#### Using karma (via karma-mocha npm package)
+If you run tests via karma in browser, you need to require/load `bdd_lazy_var*.js` (i.e., `bdd_lazy_var.js`, `bdd_lazy_var_getter.js` or `bdd_lazy_var_global.js`) and then `ui` option for mocha should be `bdd-lazy-var/global` (or `bdd-lazy-var/getter` or `bdd-lazy-var`, depends on which you prefer).
+
+**Note** requires `karma-mocha` `^1.1.1`
 
 So, in `karma.config.js` it looks like this:
 ```js
-// karma.config.js
 module.exports = function(config) {
   config.set({
     // ....
-    files: [
-      // ....
-      require.resolve('bdd-lazy-var/bdd_lazy_var_global');
-    ],
     client: {
       mocha: {
-        ui: 'bdd-lazy-var/global'
+        ui: 'bdd-lazy-var/global',
+        require: [require.resolve('bdd-lazy-var/bdd_lazy_var_global')]
       }
     }
   });
 }
 ```
-Or regular mocha configuration:
+
+#### Running mocha via JavaScript
 ```js
 let Mocha = require('mocha');
 require('bdd-lazy-var/bdd_lazy_var_global');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "main": "./index",
   "peerDependencies": {
-    "mocha": "^2.0.0"
+    "mocha": "^2.0.0",
+    "karma-mocha": "^1.1.1"
   },
   "devDependencies": {
     "browserify": "10.2.4",
@@ -33,7 +34,7 @@
     "chai-spies": "~0.7",
     "eslint": "~1.10",
     "karma": "^0.13.16",
-    "karma-mocha": "^0.2.1",
+    "karma-mocha": "^1.1.1",
     "karma-firefox-launcher": "^0.1.7",
     "mocha": "^2.0.0",
     "uglify-js": "^2.6.1"


### PR DESCRIPTION
I've updated `karma-mocha` (^1.1.1) to support requiring files after Mocha is initialised, e.g.:
```javascript
client: {
  mocha: {
    ui: 'bdd-lazy-var/global',
    require: [require.resolve('bdd-lazy-var/bdd_lazy_var_global')]
  }
}
```

This PR contains updates to the README to document this. Also bumped version of `karma-mocha` in package.json to `^1.1.1`, which contains the require feature.