### PR TITLE
Return undefined where variable does not exist

### DIFF
--- a/getter.js
+++ b/getter.js
@@ -203,7 +203,11 @@ var Metadata = function () {
     value: function getVar(name) {
       if (!this.values.hasOwnProperty(name)) {
         this.hasValues = true;
-        this.values[name] = this.defs[name].evaluate();
+        if (this.defs[name] instanceof VariableMetadata) {
+          this.values[name] = this.defs[name].evaluate();
+        } else {
+          this.values[name] = undefined;
+        }
       }
 
       return this.values[name];

--- a/global.js
+++ b/global.js
@@ -203,7 +203,11 @@ var Metadata = function () {
     value: function getVar(name) {
       if (!this.values.hasOwnProperty(name)) {
         this.hasValues = true;
-        this.values[name] = this.defs[name].evaluate();
+        if (this.defs[name] instanceof VariableMetadata) {
+          this.values[name] = this.defs[name].evaluate();
+        } else {
+          this.values[name] = undefined;
+        }
       }
 
       return this.values[name];

--- a/index.js
+++ b/index.js
@@ -203,7 +203,11 @@ var Metadata = function () {
     value: function getVar(name) {
       if (!this.values.hasOwnProperty(name)) {
         this.hasValues = true;
-        this.values[name] = this.defs[name].evaluate();
+        if (this.defs[name] instanceof VariableMetadata) {
+          this.values[name] = this.defs[name].evaluate();
+        } else {
+          this.values[name] = undefined;
+        }
       }
 
       return this.values[name];

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -58,7 +58,11 @@ class Metadata {
   getVar(name) {
     if (!this.values.hasOwnProperty(name)) {
       this.hasValues = true;
-      this.values[name] = this.defs[name].evaluate();
+      if (this.defs[name] instanceof VariableMetadata) {
+        this.values[name] = this.defs[name].evaluate();
+      } else {
+        this.values[name] = undefined;
+      }
     }
 
     return this.values[name];

--- a/spec/interface_examples.js
+++ b/spec/interface_examples.js
@@ -28,6 +28,10 @@ sharedExamplesFor('Lazy Vars Interface', function(getVar) {
       expect(getVar('staticVar')).to.equal(value);
     });
 
+    it('returns undefined where there is no definition', () => {
+      expect(getVar('notDefined')).to.equal(undefined);
+    });
+
     it('defines "get.variable" and its alias "get.definitionOf" getter builder', function() {
       expect(get.variable).to.be.a('function');
       expect(get.variable).to.equal(get.definitionOf);


### PR DESCRIPTION
Fixes an issue where calling get where the variable had not been
defined threw an error. This change restores the v1 behaviour
of returning undefined in that situation.

Fixes #31