### PR TITLE
Add `context` alias for Jest/Jasmine UI's

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 
 * **include appropriate test cases**.
 * Follow defined [Coding Rules](#rules).
-* Run all test suites `npm test`
+* Build distributable library files with `npm run build`. Run all test suites `npm test`.
 * Commit your changes using a descriptive commit message that follows defined [commit message conventions](#commit). Adherence to these conventions is necessary because release notes are automatically generated from these messages.
 * Push your branch to GitHub:
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ describe('Map', () => {
 
 ## Shortcuts
 
-Very often we want to declare several test cases which tests subject's field or subejct's behavior.
+Very often we want to declare several test cases which tests subject's field or subject's behavior.
 To do this quickly you can use `its` or `it` without message:
 
 <details>

--- a/README.md
+++ b/README.md
@@ -425,6 +425,10 @@ const { get, def } = require('bdd-lazy-var/global');
 
 All are bundled as UMD versions. Each dialect is compiled in a separate file and should be required or provided for testing framework.
 
+### Aliases
+
+In accordance with Rspec's DDL, `context`, `xcontext`, and `fcontext` have been aliased to their related `describe` commands for both the Jest and Jasmine testing libraries. Mocha's BDD interface already provides this keyword.
+
 ## The Core Features
 * lazy instantiation, allows variable composition
 * automatically cleaned after each test

--- a/getter.js
+++ b/getter.js
@@ -562,6 +562,7 @@ function optional(name) { try { return require(name) } catch(e) {} }
     context.describe = tracker.wrapSuite(context.describe);
     context.xdescribe = tracker.wrapSuite(context.xdescribe);
     context.fdescribe = tracker.wrapSuite(context.fdescribe);
+    context.context = context.describe;
     global$1.afterEach(tracker.cleanUpCurrentContext);
 
     return ui;

--- a/getter.js
+++ b/getter.js
@@ -563,6 +563,7 @@ function optional(name) { try { return require(name) } catch(e) {} }
     context.xdescribe = tracker.wrapSuite(context.xdescribe);
     context.fdescribe = tracker.wrapSuite(context.fdescribe);
     context.context = context.describe;
+    context.xcontext = context.xdescribe;
     global$1.afterEach(tracker.cleanUpCurrentContext);
 
     return ui;

--- a/getter.js
+++ b/getter.js
@@ -564,6 +564,7 @@ function optional(name) { try { return require(name) } catch(e) {} }
     context.fdescribe = tracker.wrapSuite(context.fdescribe);
     context.context = context.describe;
     context.xcontext = context.xdescribe;
+    context.fcontext = context.fdescribe;
     global$1.afterEach(tracker.cleanUpCurrentContext);
 
     return ui;

--- a/global.js
+++ b/global.js
@@ -562,6 +562,7 @@ function optional(name) { try { return require(name) } catch(e) {} }
     context.describe = tracker.wrapSuite(context.describe);
     context.xdescribe = tracker.wrapSuite(context.xdescribe);
     context.fdescribe = tracker.wrapSuite(context.fdescribe);
+    context.context = context.describe;
     global$1.afterEach(tracker.cleanUpCurrentContext);
 
     return ui;

--- a/global.js
+++ b/global.js
@@ -563,6 +563,7 @@ function optional(name) { try { return require(name) } catch(e) {} }
     context.xdescribe = tracker.wrapSuite(context.xdescribe);
     context.fdescribe = tracker.wrapSuite(context.fdescribe);
     context.context = context.describe;
+    context.xcontext = context.xdescribe;
     global$1.afterEach(tracker.cleanUpCurrentContext);
 
     return ui;

--- a/global.js
+++ b/global.js
@@ -564,6 +564,7 @@ function optional(name) { try { return require(name) } catch(e) {} }
     context.fdescribe = tracker.wrapSuite(context.fdescribe);
     context.context = context.describe;
     context.xcontext = context.xdescribe;
+    context.fcontext = context.fdescribe;
     global$1.afterEach(tracker.cleanUpCurrentContext);
 
     return ui;

--- a/index.js
+++ b/index.js
@@ -562,6 +562,7 @@ function optional(name) { try { return require(name) } catch(e) {} }
     context.describe = tracker.wrapSuite(context.describe);
     context.xdescribe = tracker.wrapSuite(context.xdescribe);
     context.fdescribe = tracker.wrapSuite(context.fdescribe);
+    context.context = context.describe;
     global$1.afterEach(tracker.cleanUpCurrentContext);
 
     return ui;

--- a/index.js
+++ b/index.js
@@ -563,6 +563,7 @@ function optional(name) { try { return require(name) } catch(e) {} }
     context.xdescribe = tracker.wrapSuite(context.xdescribe);
     context.fdescribe = tracker.wrapSuite(context.fdescribe);
     context.context = context.describe;
+    context.xcontext = context.xdescribe;
     global$1.afterEach(tracker.cleanUpCurrentContext);
 
     return ui;

--- a/index.js
+++ b/index.js
@@ -564,6 +564,7 @@ function optional(name) { try { return require(name) } catch(e) {} }
     context.fdescribe = tracker.wrapSuite(context.fdescribe);
     context.context = context.describe;
     context.xcontext = context.xdescribe;
+    context.fcontext = context.fdescribe;
     global$1.afterEach(tracker.cleanUpCurrentContext);
 
     return ui;

--- a/lib/interface/jasmine.js
+++ b/lib/interface/jasmine.js
@@ -31,6 +31,7 @@ function addInterface(rootSuite, options) {
   context.xdescribe = tracker.wrapSuite(context.xdescribe);
   context.fdescribe = tracker.wrapSuite(context.fdescribe);
   context.context = context.describe;
+  context.xcontext = context.xdescribe;
   global.afterEach(tracker.cleanUpCurrentContext);
 
   return ui;

--- a/lib/interface/jasmine.js
+++ b/lib/interface/jasmine.js
@@ -32,6 +32,7 @@ function addInterface(rootSuite, options) {
   context.fdescribe = tracker.wrapSuite(context.fdescribe);
   context.context = context.describe;
   context.xcontext = context.xdescribe;
+  context.fdescribe = context.fdescribe;
   global.afterEach(tracker.cleanUpCurrentContext);
 
   return ui;

--- a/lib/interface/jasmine.js
+++ b/lib/interface/jasmine.js
@@ -30,6 +30,7 @@ function addInterface(rootSuite, options) {
   context.describe = tracker.wrapSuite(context.describe);
   context.xdescribe = tracker.wrapSuite(context.xdescribe);
   context.fdescribe = tracker.wrapSuite(context.fdescribe);
+  context.context = context.describe;
   global.afterEach(tracker.cleanUpCurrentContext);
 
   return ui;

--- a/spec/interface_examples.js
+++ b/spec/interface_examples.js
@@ -64,6 +64,18 @@ sharedExamplesFor('Lazy Vars Interface', function(getVar) {
         expect(getVar('fullName')).to.equal('John Cusak');
       });
     });
+
+    try {
+      xcontext('skipped context', function() {
+        it('should never call assertions', function() {
+          is.expected.to.be.never.called();
+        });
+      });
+    } catch (error) {
+      it(function() {
+        is.expected.to.be.never.called();
+      });
+    }
   });
 
   describe('dynamic variable definition', function() {

--- a/spec/interface_examples.js
+++ b/spec/interface_examples.js
@@ -56,6 +56,14 @@ sharedExamplesFor('Lazy Vars Interface', function(getVar) {
         expect(getVar('fullName')).to.equal('John Smith');
       });
     });
+
+    context('nested suite using \'context\' alias', function() {
+      def('lastName', 'Cusak');
+
+      it('uses suite specific variable inside dynamic parent variable', function() {
+        expect(getVar('fullName')).to.equal('John Cusak');
+      });
+    });
   });
 
   describe('dynamic variable definition', function() {


### PR DESCRIPTION
Issue: #54 

This PR adds the following aliases for `describe` for `jest` and `jasmine`:
- `context`
- `xcontext`
- `fcontext`

MISC:
- Updated README re: new aliases
- Fixed typo in README
- Updated `CONTRIBUTING.md` to make a note about `npm run build` before running tests (otherwise, your changes wont be reflected in the testing suite.)

Notes:
- Please double-check my tests.  Not sure if I followed the pattern set forth. Also, I couldn't find an example of test that tests `fdescribe`, so unfortunately I left this untested.... Recommendations appreciated!