### PR TITLE
Add Eager def (similiar to rspec's let!) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ index.js
 global.js
 getter.js
 /*.js.map
+
+# JetBrains
+.idea/*

--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ In accordance with Rspec's DDL, `context`, `xcontext`, and `fcontext` have been 
 * ability to shadow parent's variable
 * variable inheritance with access to parent variables
 * supports typescript
+* ability to make instantiation eager (similiar to RSpec's `let!`)
 
 For more information, read [the article on Medium](https://medium.com/@sergiy.stotskiy/lazy-variables-with-mocha-js-d6063503104c#.ceo9jvrzh).
 

--- a/interface.d.ts
+++ b/interface.d.ts
@@ -4,8 +4,13 @@ interface GetLazyVar {
 
 type AnyFunction = (...args: any[]) => any;
 
+interface DefOptions {
+    lazy?: boolean;
+}
+
 export const get: GetLazyVar;
 export function def(name: string, implementation: () => any): void;
+export function def(name: string, implementation: () => any, defOptions: DefOptions): void;
 export function sharedExamplesFor(summary: string, implementation: (...vars: any[]) => void): void;
 export function itBehavesLike(summary: string | AnyFunction, ...vars: any[]): void;
 export function includeExamplesFor(summary: string | AnyFunction, ...vars: any[]): void;

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -7,23 +7,33 @@ module.exports = (context, tracker, options) => {
 
   get.definitionOf = get.variable = (varName) => get.bind(null, varName);
 
-  function def(varName, definition) {
+  function def(varName, definition, defOptions = {}) {
     const suite = tracker.currentlyDefinedSuite;
+    const isEager = 'lazy' in defOptions && defOptions.lazy === false;
 
     if (!Array.isArray(varName)) {
       Metadata.ensureDefinedOn(suite).addVar(varName, definition);
       runHook('onDefineVariable', suite, varName);
+
+      if (isEager) {
+        Metadata.of(suite).evaluate(varName);
+      }
+
       return;
     }
 
     const [name, ...aliases] = varName;
-    def(name, definition);
+    def(name, definition, defOptions);
 
     const metadata = Metadata.of(suite);
     aliases.forEach((alias) => {
       metadata.addAliasFor(name, alias);
       runHook('onDefineVariable', suite, alias);
     });
+
+    if (isEager) {
+      metadata.evaluate(name);
+    }
   }
 
   function subject(...args) {

--- a/lib/symbol.js
+++ b/lib/symbol.js
@@ -1,5 +1,5 @@
-const indentity = (x) => x;
+const identity = (x) => x;
 
 module.exports = {
-  for: typeof Symbol === 'undefined' ? indentity : Symbol.for
+  for: typeof Symbol === 'undefined' ? identity : Symbol.for
 };

--- a/spec/interface_examples.js
+++ b/spec/interface_examples.js
@@ -345,11 +345,46 @@ sharedExamplesFor('Lazy Vars Interface', function(getVar) {
   });
 });
 
+class SpyUtilityClass {
+  static functionThatShouldNotBeCalledBecauseLazyIsOffByDefault = spy();
+  static functionThatShouldNotBeCalledBecauseLazyWasExplicitlySetToTrue = spy();
+  static functionThatShouldBeCalled = spy();
+}
+
 sharedExamplesFor('Root Lazy Vars', function(getVar) {
-  const varName = `hello.${Date.now()}.${Math.random()}`
+  const varName = `hello.${Date.now()}.${Math.random()}`;
+  const nonLazyVarName = `nonLazy.${Date.now()}.${Math.random()}`;
+  const lazyVarName = `lazy.${Date.now()}.${Math.random()}`;
+  const explicitlyLazyVarName = `explicitlyLazy.${Date.now()}.${Math.random()}`;
+  const implicitlyLazyVarName = `implicitlyLazy.${Date.now()}.${Math.random()}`;
+
 
   def(varName, function() {
-    return 'world'
+    return 'world';
+  });
+
+  def(nonLazyVarName, function() {
+    SpyUtilityClass.functionThatShouldBeCalled();
+  }, { lazy: false });
+
+  def(implicitlyLazyVarName, function() {
+    SpyUtilityClass.functionThatShouldNotBeCalledBecauseLazyIsOffByDefault();
+  });
+
+  def(explicitlyLazyVarName, function() {
+    SpyUtilityClass.functionThatShouldNotBeCalledBecauseLazyWasExplicitlySetToTrue();
+  });
+
+  it('should eagerly evaluate defs with {lazy: false}', function() {
+    expect(SpyUtilityClass.functionThatShouldBeCalled).to.have.been.called.once;
+  });
+
+  it('should lazily evaluate defs with {lazy: true}', function() {
+    expect(SpyUtilityClass.functionThatShouldNotBeCalledBecauseLazyWasExplicitlySetToTrue).not.to.have.been.called();
+  });
+
+  it('should lazily evaluate by default', function() {
+    expect(SpyUtilityClass.functionThatShouldNotBeCalledBecauseLazyIsOffByDefault).not.to.have.been.called();
   });
 
   it('allows to define lazy vars at root level', function() {


### PR DESCRIPTION
# Solves
This PR Solves https://github.com/stalniy/bdd-lazy-var/issues/113

# Context
This PR allows you to specify a `def` with `{lazy: false}` to make it eagerly evaluate instead of lazily.
This is very similiar to how `let` and `let!` are different in the RSpec library.

My use case for this feature is a sequelize ORM creation of an object. 
Not all `it`s needs the `id` of the object or even the object at all, because they are testing other side effects of the call. (for example, validations, errors being thrown, HTTP calls being sent out).
Some however, do test the object.
